### PR TITLE
bug fixes and downloading portals

### DIFF
--- a/evilportal/projects/evilportal/src/lib/components/evilportal.component.html
+++ b/evilportal/projects/evilportal/src/lib/components/evilportal.component.html
@@ -174,6 +174,7 @@
                         <button mat-button color="warn" *ngIf="portal.active" (click)="togglePortal(portal.title);">Deactivate</button>
                     </td>
                     <td class="mat-cell">
+                        <button mat-raised-button color="accent" class="control-button" (click)="downloadPortal(portal);">Download</button>
                         <button mat-raised-button color="warn" class="control-button" *ngIf="!portal.active" (click)="showDeletePortalDialog(portal.location);">Delete</button>
                         <button mat-raised-button color="accent" class="control-button" *ngIf="portal.active" (click)="showPreviewDialog();">Preview</button>
                         <button mat-raised-button color="accent" class="control-button" *ngIf="portal.active" class="control-button" (click)="editFile(portal, '.logs', true);">View Log</button>

--- a/evilportal/projects/evilportal/src/lib/components/evilportal.component.ts
+++ b/evilportal/projects/evilportal/src/lib/components/evilportal.component.ts
@@ -115,8 +115,9 @@ export class EvilPortalComponent implements OnInit, OnDestroy {
             action: 'load_file',
             path: path
         }, (response) => {
-            if (response.error !== undefined) {
-                onComplete(false, undefined, response.error);
+            if (response === undefined || response.error !== undefined) {
+                let error = (response !== undefined) ? response.error : '';
+                onComplete(false, undefined, error);
                 return
             }
             onComplete(true, response, undefined);
@@ -335,6 +336,22 @@ export class EvilPortalComponent implements OnInit, OnDestroy {
             }
 
             this.loadControlState();
+        });
+    }
+
+    downloadPortal(portal: PortalInfoDTO): void {
+        this.API.request({
+            module: 'evilportal',
+            action: 'archive_portal',
+            portal: portal.title
+        }, (response) => {
+            if (response.error !== undefined) {
+                this.handleError(response.error);
+                return;
+            }
+
+            this.API.APIDownload(response, portal.title + '.tar.gz');
+            this.delete(response, () => {});
         });
     }
 

--- a/evilportal/projects/evilportal/src/module.json
+++ b/evilportal/projects/evilportal/src/module.json
@@ -3,5 +3,5 @@
     "title": "Evil Portal",
     "description": "An evil captive portal for the WiFi Pineapple.",
     "author": "newbi3",
-    "version": "1.0"
+    "version": "1.1"
 }

--- a/evilportal/projects/evilportal/src/module.py
+++ b/evilportal/projects/evilportal/src/module.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+
+from typing import Dict, Tuple, List, Union, Optional
 import json
 import subprocess
-from typing import Dict, Tuple, List, Union, Optional
 import logging
 import pathlib
+import tarfile
 import os
 
 from pineapple.modules import Module, Request
@@ -406,7 +408,7 @@ def get_portal_rules(request: Request):
 @module.handles_action('new_portal')
 def new_portal(request: Request):
     type_to_skeleton = {'basic': 'skeleton', 'targeted': 'targeted_skeleton'}
-    name = request.name
+    name = request.name.title().replace(' ', '')
     portal_type = request.type
     skeleton = type_to_skeleton.get(portal_type, 'skeleton')
 
@@ -428,6 +430,20 @@ def new_portal(request: Request):
         os.system(f"sed -i 's/\"portal_name_here\"/\"{name}\"/g' {_PORTAL_PATH}/{name}/index.php")
 
     return 'Portal created successfully.'
+
+
+@module.handles_action('archive_portal')
+def archive_portal(request: Request):
+    name = request.portal
+    portal_path = pathlib.Path(f'{_PORTAL_PATH}/{name}')
+
+    if not portal_path.is_dir():
+        return 'A portal with the given name does not exist.', False
+
+    with tarfile.open(f'/tmp/{name}.tar.gz', 'w:gz') as tar:
+        tar.add(str(portal_path), portal_path.name)
+
+    return f'/tmp/{name}.tar.gz'
 
 
 @module.handles_action('save_file')


### PR DESCRIPTION
Fixed bug where Allowed Clients spinner doesn't stop spinning until EP is started.
Fixed bug where portals with spaces in their names arent created correctly
Added ability to download portals from the Portal Library