### PR TITLE
Evilportal preview fix.

### DIFF
--- a/evilportal/package-lock.json
+++ b/evilportal/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "evilportal",
             "version": "0.0.0",
             "dependencies": {
                 "@angular/animations": "~9.1.11",

--- a/evilportal/projects/evilportal/src/lib/components/helpers/preview-dialog/preview-dialog.component.html
+++ b/evilportal/projects/evilportal/src/lib/components/helpers/preview-dialog/preview-dialog.component.html
@@ -12,7 +12,6 @@
     <br/>
 
     <div class="previewContainer">
-        <iframe class="previewWindow" src="http://172.16.42.1"></iframe>
+        <iframe id="preview" class="previewWindow"></iframe>
     </div>
-
 </div>

--- a/evilportal/projects/evilportal/src/lib/components/helpers/preview-dialog/preview-dialog.component.ts
+++ b/evilportal/projects/evilportal/src/lib/components/helpers/preview-dialog/preview-dialog.component.ts
@@ -8,6 +8,9 @@ import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
 })
 export class PreviewDialogComponent implements OnInit {
 
+    hostname = '';
+    hostnamediv = '';
+
     constructor(public dialogRef: MatDialogRef<PreviewDialogComponent>,
                 @Inject(MAT_DIALOG_DATA) public data: any) {}
 
@@ -16,6 +19,9 @@ export class PreviewDialogComponent implements OnInit {
     }
 
     ngOnInit(): void {
+        this.hostname = 'http://'+window.location.hostname;
+        let hostnamediv = document.getElementById('preview');
+        hostnamediv.setAttribute('src', this.hostname);
     }
 
 }


### PR DESCRIPTION
Make evilportal use window.location.hostname instead of predefined 172.16.42.1 for previews.