### PR TITLE
[Evilportal] fixed notify and handleAuthorization method in baseclass portal

### DIFF
--- a/evilportal/projects/evilportal/src/assets/api/Portal.php
+++ b/evilportal/projects/evilportal/src/assets/api/Portal.php
@@ -39,7 +39,7 @@ abstract class Portal
      */
     protected final function notify($message)
     {
-        $this->execBackground("notify {$message}");
+        $this->execBackground("PYTHONPATH=/usr/lib/pineapple; export PYTHONPATH; /usr/bin/python3 /usr/bin/notify info '{$message}' evilportal");
     }
 
     /**

--- a/evilportal/projects/evilportal/src/assets/api/Portal.php
+++ b/evilportal/projects/evilportal/src/assets/api/Portal.php
@@ -42,6 +42,7 @@ abstract class Portal
         $this->execBackground("PYTHONPATH=/usr/lib/pineapple; export PYTHONPATH; /usr/bin/python3 /usr/bin/notify info '{$message}' evilportal");
     }
 
+
     /**
      * Write a log to the portals log file.
      * These logs can be retrieved from the web UI for .logs in the portals directory.
@@ -81,15 +82,15 @@ abstract class Portal
      */
     protected function handleAuthorization()
     {
-        if (isset($this->request->target)) {
-            $this->authorizeClient($_SERVER['REMOTE_ADDR']);
-            $this->onSuccess();
+        if ($this->isClientAuthorized($_SERVER['REMOTE_ADDR']) and isset($this->request->target)) {
             $this->redirect();
-        } elseif ($this->isClientAuthorized($_SERVER['REMOTE_ADDR'])) {
-            $this->redirect();
-        } else {
-            $this->showError();
-        }
+         } elseif (isset($this->request->target)) {
+             $this->authorizeClient($_SERVER['REMOTE_ADDR']);
+             $this->onSuccess();
+             $this->redirect();
+         } else {
+             $this->showError();
+         } 
     }
 
     /**


### PR DESCRIPTION
1) fixed notify method in baseclass portal

![image](https://user-images.githubusercontent.com/121891501/212972751-4011187b-ded2-41d8-bc5b-837963b07a70.png)

2) Fixed logic in handleAuthorization method in baseclass portal to prevent an auth loop

a logic bug can arise if the Pineapple misbehaves. So long as the redirection is set, if the Captive Portal happens to continue displaying, this logic will continually reauthorize the client over and over again, filling the authorized user log with the same IP address. Its fixed in this PR
