### PR TITLE
[Evilportal] fixed logic in handleAuthorization method in baseclass portal to prevent an authloop

### DIFF
--- a/evilportal/projects/evilportal/src/assets/api/Portal.php
+++ b/evilportal/projects/evilportal/src/assets/api/Portal.php
@@ -39,7 +39,7 @@ abstract class Portal
      */
     protected final function notify($message)
     {
-        $this->execBackground("notify {$message}");
+        $this->execBackground("PYTHONPATH=/usr/lib/pineapple; export PYTHONPATH; /usr/bin/python3 /usr/bin/notify info '{$message}' evilportal");
     }
 
     /**


### PR DESCRIPTION
a logic bug can arise if the Pineapple misbehaves. So long as the redirection is set, if the Captive Portal happens to continue displaying, this logic will continually reauthorize the client over and over again, filling the authorized user log with the same IP address. Its fixed in this PR