### PR TITLE
[Evilportal] fixed logic in handleAuthorization method in baseclass portal to prevent an auth loop

### DIFF
--- a/evilportal/projects/evilportal/src/assets/api/Portal.php
+++ b/evilportal/projects/evilportal/src/assets/api/Portal.php
@@ -81,15 +81,15 @@ abstract class Portal
      */
     protected function handleAuthorization()
     {
-        if (isset($this->request->target)) {
-            $this->authorizeClient($_SERVER['REMOTE_ADDR']);
-            $this->onSuccess();
+        if ($this->isClientAuthorized($_SERVER['REMOTE_ADDR']) and isset($this->request->target)) {
             $this->redirect();
-        } elseif ($this->isClientAuthorized($_SERVER['REMOTE_ADDR'])) {
-            $this->redirect();
-        } else {
-            $this->showError();
-        }
+         } elseif (isset($this->request->target)) {
+             $this->authorizeClient($_SERVER['REMOTE_ADDR']);
+             $this->onSuccess();
+             $this->redirect();
+         } else {
+             $this->showError();
+         } 
     }
 
     /**


### PR DESCRIPTION
fixed logic in handleAuthorization method in baseclass portal to prevent an auth loop

a logic bug can arise if the Pineapple misbehaves. So long as the redirection is set, if the Captive Portal happens to continue displaying, this logic will continually reauthorize the client over and over again, filling the authorized user log with the same IP address

The problem is that in many cases, for whatever reason, the value in $this->request->target is not set causing the logic branch to fail. Or, the value reflects /captiveportal/index.php which was the form destination, meaning the portal gets reloaded instead of the intended webpage. Basically, this results in the function to redirect either never getting called, getting called without definition, or getting called back to the portal anyway. 